### PR TITLE
Include schema_name in input type for delete current refresh_token

### DIFF
--- a/backend/src/auth/index.js
+++ b/backend/src/auth/index.js
@@ -255,7 +255,7 @@ router.post('/refresh-token', async (req, res, next) => {
   query = `
   mutation (
     $old_refresh_token: uuid!,
-    $new_refresh_token_data: refresh_tokens_insert_input!
+    $new_refresh_token_data: ${schema_name}refresh_tokens_insert_input!
     $user_id: Int!
   ) {
     delete_${schema_name}refresh_tokens (


### PR DESCRIPTION
The graphql call works for a public schema (without schema name prefix) but doesn't for other than public schemas. Need to include the schema name in the generated input type when deleting the current refresh_token.